### PR TITLE
Add setup-ci.cfg to fix ci bug

### DIFF
--- a/setup-ci.cfg
+++ b/setup-ci.cfg
@@ -1,0 +1,10 @@
+[nosetests]
+verbosity=3
+
+# with-progressive=1
+
+rednose=1
+
+with-tissue=1
+tissue-inclusive=1
+tissue-statistics=1


### PR DESCRIPTION
Bug: All tests passing on local failing but semaphore

Cause: Semaphore can not run nose-notify

Solution: Add a new file called setup-ci.cfg to differentiate the tests to be run on dev machines from those run as part to the CI process.